### PR TITLE
update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ Welcome! To find out more about the progress we have already made, have a look a
 
 The current setup relies on a legacy version of Node (verion 8.17.0). For the initial setup make sure to have this version installed and then run the following commands:
 
-`nvm use 8.17.0` (temporary workaround, needed for legacy version of gulp)
-`yarn` (installs the environment)
-`gulp` (starts your local dev server)
+- `nvm use 8.17.0` (temporary workaround, needed for legacy version of gulp)
+- `yarn` (installs the environment)
+- `gulp` (starts your local dev server, in case you don't have gulp installed, refer to the [Gulp Quick Start guide](https://gulpjs.com/docs/en/getting-started/quick-start/#install-the-gulp-command-line-utility))
 
 To publish everything, run `gulp publish` and commit the changes (via a pull request) to master.
 

--- a/README.md
+++ b/README.md
@@ -6,18 +6,12 @@ Welcome! To find out more about the progress we have already made, have a look a
 
 The current setup relies on a legacy version of Node (verion 8.17.0). For the initial setup make sure to have this version installed and then run the following commands:
 
-- `nvm use 8.17.0` (temporary workaround, needed for legacy version of gulp)
+- `nvm use 8.17.0` (useful if you easily want to be able to switch between node versions)
 - `yarn` (installs the environment)
 - `gulp` (starts your local dev server, in case you don't have gulp installed, refer to the [Gulp Quick Start guide](https://gulpjs.com/docs/en/getting-started/quick-start/#install-the-gulp-command-line-utility))
 
-To publish everything, run `gulp publish` and commit the changes (via a pull request) to master.
-
-In the near future we are planning to migrate the entire web app over to React and the latest stable version of Node.
+In case you make changes to JavaScript files, you can run `gulp publish` to uglify the code. In most cases, it will be sufficient to only run `gulp` while working locally. 
 
 ## Update instructions
 
 To update the landing page of climatemind.org, change the respective file in the `/src/` folder (e.g. `src/index.pug`), run `gulp` (to start your local dev server), and then commit + push the changes to GitHub. 
-
-## Remarks
-
-Our cloud computing is proudly sponsored by Microsoft through an [AI for Earth grant](https://www.microsoft.com/ai/ai-for-earth).


### PR DESCRIPTION
The command to first install the gulp cli locally was missing.

Either we add the following line to our readme (and change from using yarn to using npm)
`npm install --global gulp-cli`

or we link to the following document:
https://gulpjs.com/docs/en/getting-started/quick-start/#install-the-gulp-command-line-utility

What do you think @y-himanen? 
